### PR TITLE
remove 'use-serde' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,4 @@ serde = { version = "1.0", features = [ "derive" ] }
 
 [features]
 default = [ "use-structs" ]
-use-serde = [ "serde" ]
 use-structs = []


### PR DESCRIPTION
cargo automatically adds a 'serde' feature when including serde as an optional dependency. Using the automatically added feature is, by api guidelines, the preferred way.

https://rust-lang.github.io/api-guidelines/interoperability.html#c-serde

Some more PRs incoming ;) Thanks for implementing!